### PR TITLE
feat: plan user requests into categorized subtasks

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -22,6 +22,21 @@ body {
     padding: 10px;
     height: 300px;
   }
+
+  .tasks {
+    padding: 10px;
+    border-top: 1px solid #ccc;
+    max-height: 150px;
+    overflow-y: auto;
+    background: #fafafa;
+  }
+
+  .task {
+    border: 1px solid #ddd;
+    margin: 5px 0;
+    padding: 5px;
+    font-size: 0.9em;
+  }
   
   .user-msg, .bot-msg {
     margin: 5px 0;

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,6 +8,7 @@
 <body>
   <div class="chat-container">
     <div id="chat-box" class="chat-box"></div>
+    <div id="tasks" class="tasks"></div>
     <form id="chat-form">
       <input type="text" id="user-input" placeholder="Message..." required>
       <button>Envoyer</button>
@@ -31,6 +32,14 @@
       const data = await res.json();
       chatBox.innerHTML += `<div class="bot-msg"><b>Ollama:</b> ${data.reply}</div>`;
       chatBox.scrollTop = chatBox.scrollHeight;
+
+      const tasksDiv = document.getElementById('tasks');
+      tasksDiv.innerHTML = '';
+      if (data.tasks) {
+        data.tasks.forEach(task => {
+          tasksDiv.innerHTML += `<div class="task ${task.type}"><b>${task.id}</b>: ${task.description}</div>`;
+        });
+      }
     };
   </script>
 </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Myrmex</title>
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
   <div class="chat-container">
@@ -35,7 +35,7 @@
 
       const tasksDiv = document.getElementById('tasks');
       tasksDiv.innerHTML = '';
-      if (data.tasks) {
+      if (Array.isArray(data.tasks)) {
         data.tasks.forEach(task => {
           tasksDiv.innerHTML += `<div class="task ${task.type}"><b>${task.id}</b>: ${task.description}</div>`;
         });


### PR DESCRIPTION
## Summary
- add structured planning prompt to break user requests into deep_think and deep_research tasks
- expose plan results to front-end and render task list with basic styles

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_688f8829ab7c832d8ec962be9d28f9b7